### PR TITLE
load video from webxdc.org

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -2,7 +2,7 @@
 
 Webxdc is a new way to create and share web apps in messenger chat groups. Anyone can build HTML5 apps, package it as a [`.xdc` file](spec.md#webxdc-file-format), and and drop it in a chat to share with friends. Once shared, chat participants can simply click "Start" to run the app and interact with each other through the app. 
 
-<video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.github.io/website/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
+<video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.org/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
 
 Webxdc apps can only send and receive messages in the chat via the messenger's [Javascript API]. Thus they automatically get end-to-end encryption and peer discovery for free.
 


### PR DESCRIPTION
webxdc.org is live, no need to route over github.io any longer

closes #19