### PR TITLE
Update tips_and_tricks.md: how to open dev tools on desktop

### DIFF
--- a/src/tips_and_tricks.md
+++ b/src/tips_and_tricks.md
@@ -116,6 +116,12 @@ style="max-height:40vh"
 
 ### Debug Your webxdc Content in DeltaChat Desktop
 
+First enable the devTools for webxdc in the Settings:
+
+settings -> experimental -> Enable Webxdc Devtools
+
+> Note that you need to close and open any active webxdcs again for changes to take effect
+
 Start the webxdc you want to debug and press `F12` to open the developer tools:
 
 <p>


### PR DESCRIPTION
as we changed the way to get the dev tools on desktop, the docs now need to be updated too.