### PR TITLE
refactor: webxdc.d.ts: a little better types

### DIFF
--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -120,9 +120,7 @@ interface Webxdc<T> {
 
 ////////// ANCHOR: global
 declare global {
-  interface Window {
-    webxdc: Webxdc<any>;
-  }
+  var webxdc: Webxdc<any>;
 }
 ////////// ANCHOR_END: global
 


### PR DESCRIPTION
Make it possible to use bare `webxdc` or `globalThis.webxd` instead of only `window.webxdc`

FYI I accidentally pushed this to `master`: d4d9b7bb95488d870e658b280165dc036355a773, but then reverted 72212a3f232ee272fb078eb8a107bb944fe13d0e