### PR TITLE
refine/update webxdc docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-- [Intro](./intro.md)
+- [From HTTP to P2P web apps](./intro.md)
 - [Get Started](./get_started.md)
 - [Webxdc Specification](./spec/README.md)
   - [sendUpdate](./spec/sendUpdate.md)

--- a/src/faq/compat.md
+++ b/src/faq/compat.md
@@ -11,8 +11,8 @@ Webxdc apps run in a restricted environment, but the following practices are per
 - internal links, such as `<a href="localfile.html">`
 - `mailto` links, such as `<a href="mailto:addr@example.org?body=...">`
 - `<meta name="viewport" ...>` is useful especially as webviews from different platforms have different defaults
-- `<input type="file">` allows importing of files for further processing (requires Delta Chat 1.38 or compatible);
-  see [`sendToChat()`](/spec/sendToChat.md) for a way to export files
+- `<input type="file">` allows importing of files for further
+  processing; see [`sendToChat()`](/spec/sendToChat.md) for a way to export files
 
 ### Discouraged Practises 
 

--- a/src/get_started.md
+++ b/src/get_started.md
@@ -42,15 +42,21 @@ Now it's possible to share the `myapp.xdc` file in any chat: recipients can hit 
 To simulate multiple chat participants in the browser, try [Hello](https://github.com/webxdc/hello) as a minimal example; it includes everything needed to run the app and requires no build systems.
 
 
-## More examples
+## More examples and the webxdc store 
 
-Source code for apps referenced on the [webxdc home page](https://webxdc.org) can be found in the [Webxdc GitHub organization](https://github.com/webxdc).
+The [hello webxdc app](https://github.com/webxdc/hello) is a good "getting-started" app 
+for tweaking and producing modified apps that directly work in webxdc supporting messengers. 
 
+The [webxdc app store](https://webxdc.org/apps) contains working webxdc apps that you can use today. 
+Each app comes with a "source code" link so that you can learn and fork as you wish. 
+You can submit your own available FOSS app for inclusion. 
 
 ## Participating in developments 
 
-- [Webxdc GitHub organization](https://github.com/webxdc): contains many example app repositories. Please tag your own app experiments with "webxdc" so that others can find it via the [`#webxdc` Topic on GitHub](https://github.com/topics/webxdc). 
-
 - [Support Forum](https://support.delta.chat/c/webxdc/20): the webxdc category on the DeltaChat forum is a space to ask questions and announce your app projects. Log into the [forum](https://support.delta.chat) via DeltaChat, Github, or by creating a username and password there.
 
-- Announcements: Delta Chat and Webxdc-related developments can be followed on [Fediverse](https://chaos.social/@delta) or [Twitter](https://twitter.com/delta_chat). 
+- If you have any question about Webxdc support in the XMPP-based Cheogram messenger, head over
+  to the [Cheogram forum channel](https://anonymous.cheogram.com/discuss@conference.soprani.ca)
+
+- Announcements: Delta Chat and Webxdc-related developments can be
+  followed on [Fediverse](https://chaos.social/@delta)

--- a/src/get_started.md
+++ b/src/get_started.md
@@ -42,14 +42,11 @@ Now it's possible to share the `myapp.xdc` file in any chat: recipients can hit 
 To simulate multiple chat participants in the browser, try [Hello](https://github.com/webxdc/hello) as a minimal example; it includes everything needed to run the app and requires no build systems.
 
 
-## More examples and the webxdc store 
+## More examples in the webxdc store 
 
-The [hello webxdc app](https://github.com/webxdc/hello) is a good "getting-started" app 
-for tweaking and producing modified apps that directly work in webxdc supporting messengers. 
-
-The [webxdc app store](https://webxdc.org/apps) contains working webxdc apps that you can use today. 
+The [webxdc store](https://webxdc.org/apps) contains working webxdc apps that you can use today. 
 Each app comes with a "source code" link so that you can learn and fork as you wish. 
-You can submit your own available FOSS app for inclusion. 
+You can submit your own available FOSS app for inclusion into the curated store. 
 
 ## Participating in developments 
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -1,34 +1,42 @@
-# From HTTP to P2P web apps
+# From online-HTTP to offline-first P2P web apps
 
-Webxdc is a container format for sharing and hosting HTML5 web apps in messenger chats. 
+Webxdc is a P2P oriented container format for sharing and hosting HTML5 web apps in messenger chats. 
+The e-mail based [Delta Chat](https://delta.chat) and the XMPP-based [Cheogram](https://cheogram.com) messengers 
+support [webxdc apps](https://webxdc.org/apps) which work in both messengers without any change, today. 
+In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security) 
+Delta Chat developers described the security-audited privacy guarantees of webxdc 
+not found with any other web container technology or [specification](./spec/index.html). 
+
 Instead of being hosted on a central always-online HTTP server, 
-webxdc apps are hosted in a messenger app by attaching a container file to a chat message,
-and can be used while a device is offline even for extended periods. 
+webxdc apps are hosted in a messenger app by attaching a container file to a chat message. 
+Apps can be used while a device is offline even for extended periods
+if their host messenger supports offline-first operations like Delta Chat does. 
 Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
 webxdc apps send and receive messages via the messenger's [JavaScript API]
-which routes all "application updates" between devices running a particular webxdc app. 
-Webxdc app developers do not need to implement user authentication, discovery or bootstrapping mechanisms,
-and they do not need to implement end-to-end encryption, 
-all of which are already provided by the messenger hosting the webxdc app. 
+which routes all "application updates" between devices running a particular webxdc container app. 
+App developers do not need to implement user authentication, discovery or bootstrapping mechanisms,
+and they do not need to implement end-to-end encryption either. 
+All Authentication, identity management, social discovery and message transport 
+is outsourced to the host messenger which runs webxdc apps. 
+
+Waving central registries and app store dependencies "good bye!", 
+anyone can [get started building a HTML5 app](/get_started.html), 
+package it as a [`.xdc` container file](./spec/index.html#webxdc-file-format), 
+and drop it in a chat to share with friends. 
+Once shared, chat participants click "Start" 
+thereby instantiating an ad-hoc distributed P2P system on participant's devices,
+where the hosting messenger provides the social and technical routing of "application updates". 
+As long and as well as the hosting messenger manages to deliver messages, 
+webxdc application state is constantly replicated and synchronized across all participating devices. 
 
 While webxdc app development is fundamentally easier 
-than developing for and maintaining an application-specific HTTP server 
+than developing for and maintaining an application-specific always-online HTTP server 
 there are complications in arranging consistent web app state across user's devices,
 a typical issue for any P2P system. 
 The [Shared web application state] chapter 
 provides useful theoretical and practical background for writing robust offline-first web apps
 without requiring a central online authority acting as the "source of truth". 
 
-If you are interested in the privacy and security guarantees of webxdc, 
-you may read [Bringing E2E privacy to the web](https://delta.chat/en/2023-05-22-webxdc-security) 
-which describes security-audited privacy guarantees of webxdc not found with any other web container technology. 
-
-Removing central registries and app stores means that 
-anyone can [get started building a HTML5 app](/get_started.html), 
-package it as a [`.xdc` container file](./spec/index.html#webxdc-file-format), 
-and drop it in a chat to share with friends. 
-Once shared, chat participants can simply click "Start" 
-to run the app and interact with each other through the app.
 
 <video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.org/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
 
@@ -40,8 +48,10 @@ No messenger is required to develop a webxdc app with the `webxdc-dev` tool.
 [webxdc on Codeberg](https://codeberg.org/webxdc) and [webxdc on GitHub](https://github.com/webxdc) 
 contain some of the ongoing webxdc-related developments.  
 
-Please feel free to post or follow questions and answers 
+For now, please feel free to post or follow questions and answers 
 in the [Webxdc support forum](https://support.delta.chat/c/webxdc/20). 
+If somebody wants to help with setting up more independent 
+webxdc community infrastructure please step forward. 
 
 [Shared web application state]: /shared-state/index.html 
 [JavaScript API]: /spec/index.html#webxdc-api

--- a/src/intro.md
+++ b/src/intro.md
@@ -6,17 +6,17 @@ webxdc apps are hosted in a messenger app by attaching a container file to a cha
 and can be used while a device is offline even for extended periods. 
 Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
 webxdc apps send and receive messages via the messenger's [JavaScript API]
-which routes all "application updates" between users of an app.
+which routes all "application updates" between devices running a particular webxdc app. 
 Webxdc app developers do not need to implement user authentication, discovery or bootstrapping mechanisms,
 and they do not need to implement end-to-end encryption, 
-all of which is already provided by the messenger hosting the webxdc app. 
+all of which are already provided by the messenger hosting the webxdc app. 
 
 While webxdc app development is fundamentally easier 
 than developing for and maintaining an application-specific HTTP server 
 there are complications in arranging consistent web app state across user's devices,
-typical for any P2P system. 
+a typical issue for any P2P system. 
 The [Shared web application state] chapter 
-provides neccessary theoretical and practical background for writing robust offline-first web apps
+provides useful theoretical and practical background for writing robust offline-first web apps
 without requiring a central online authority acting as the "source of truth". 
 
 If you are interested in the privacy and security guarantees of webxdc, 

--- a/src/intro.md
+++ b/src/intro.md
@@ -2,22 +2,27 @@
 
 Webxdc is a P2P oriented container format for sharing and hosting HTML5 web apps in messenger chats. 
 The e-mail based [Delta Chat](https://delta.chat) and the XMPP-based [Cheogram](https://cheogram.com) messengers 
-support [webxdc apps](https://webxdc.org/apps) which work in both messengers without any change, today. 
-In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security) 
-Delta Chat developers described the security-audited privacy guarantees of webxdc 
-not found with any other web container technology or [specification](./spec/index.html). 
+support [webxdc apps](https://webxdc.org/apps), which run on both messengers without any change. 
 
 Instead of being hosted on a central always-online HTTP server, 
-webxdc apps are hosted in a messenger app by attaching a container file to a chat message. 
-Apps can be used while a device is offline even for extended periods
-if their host messenger supports offline-first operations like Delta Chat does. 
+webxdc apps are stored with the host messenger by attaching a container file to a chat message. 
 Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
 webxdc apps send and receive messages via the messenger's [JavaScript API]
-which routes all "application updates" between devices running a particular webxdc container app. 
-App developers do not need to implement user authentication, discovery or bootstrapping mechanisms,
-and they do not need to implement end-to-end encryption either. 
+which allows to send and receive "application updates" between devices particpating in a chat. 
+App developers do not need to implement message transport, user authentication, 
+discovery or bootstrapping mechanisms, and they do not need to implement end-to-end encryption either. 
 All Authentication, identity management, social discovery and message transport 
-is outsourced to the host messenger which runs webxdc apps. 
+is outsourced to the host messenger which runs webxdc apps,
+thereby letting each app inherit offline-first and end-to-end encryption 
+capabilities of the hosting messenger. 
+
+Messengers run webxdc container files in network-isolated webviews that can not perform any DNS or HTTP queries.
+Webxdc apps can only cause network messages by calling the [`sendUpdate`](./spec/sendUpdate.html)
+and [`setUpdateListener`](./spec/setUpdateListener.html) Javasript APIs,
+implemented by the hosting messenger. 
+In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security) 
+Delta Chat developers described the unqiue security-audited privacy guarantees of webxdc 
+not found with any other web container technology or [specification](./spec/index.html). 
 
 Waving central registries and app store dependencies "good bye!", 
 anyone can [get started building a HTML5 app](/get_started.html), 
@@ -29,21 +34,25 @@ where the hosting messenger provides the social and technical routing of "applic
 As long and as well as the hosting messenger manages to deliver messages, 
 webxdc application state is constantly replicated and synchronized across all participating devices. 
 
-While webxdc app development is fundamentally easier 
-than developing for and maintaining an application-specific always-online HTTP server 
-there are complications in arranging consistent web app state across user's devices,
-a typical issue for any P2P system. 
+<video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.org/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
+
+
+The [webxdc-dev simulation tool](https://github.com/webxdc/webxdc-dev) is the recommended 
+tool for developing webxdc apps as it allows multi-user simulation, 
+and allows observing network messages between app instances. 
+No messenger is required to develop a webxdc app with the `webxdc-dev` tool. 
+
+Webxdc app development and deployment is fundamentally easier than 
+developing for and maintaining an application-specific always-online HTTP server. 
+But there are undeniably complications in arranging consistent web app state 
+across user's devices, a typical issue for any P2P system. 
 The [Shared web application state] chapter 
 provides useful theoretical and practical background for writing robust offline-first web apps
 without requiring a central online authority acting as the "source of truth". 
+Even if you don't study the topic in depth, reading [Shared web application state] 
+introduces you to the terminology and neccessary considerations 
+for any P2P system, with a particular eye on webxdc. 
 
-
-<video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.org/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
-
-The [webxdc-dev simulation tool](https://github.com/webxdc/webxdc-dev) is the recommended 
-tool for developing webxdc apps as it allows simulation of multiple app users,
-supports different screen formats and allows observing network messages between app instances. 
-No messenger is required to develop a webxdc app with the `webxdc-dev` tool. 
 
 [webxdc on Codeberg](https://codeberg.org/webxdc) and [webxdc on GitHub](https://github.com/webxdc) 
 contain some of the ongoing webxdc-related developments.  

--- a/src/intro.md
+++ b/src/intro.md
@@ -2,24 +2,26 @@
 
 Webxdc is a container format for sharing and hosting HTML5 web apps in messenger chats. 
 Instead of being hosted on a central always-online HTTP server, 
-webxdc apps are stored in a messenger app by attaching a container file to a chat message,
+webxdc apps are hosted in a messenger app by attaching a container file to a chat message,
 and can be used while a device is offline even for extended periods. 
 Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
 webxdc apps send and receive messages via the messenger's [JavaScript API]
 which routes all "application updates" between users of an app.
-Webxdc app developers do not need to implement user accounts or discovery mechanisms,
+Webxdc app developers do not need to implement user authentication, discovery or bootstrapping mechanisms,
 and they do not need to implement end-to-end encryption, 
-all of which are already provided by the messenger hosting the webxdc app. 
+all of which is already provided by the messenger hosting the webxdc app. 
 
-While webxdc app development is vastly easier than developing for the HTTP Cloud
-there also are complications in arranging consistent web app state across user's devices. 
-The [Shared web application state] section 
+While webxdc app development is fundamentally easier 
+than developing for and maintaining an application-specific HTTP server 
+there are complications in arranging consistent web app state across user's devices,
+typical for any P2P system. 
+The [Shared web application state] chapter 
 provides neccessary theoretical and practical background for writing robust offline-first web apps
 without requiring a central online authority acting as the "source of truth". 
 
 If you are interested in the privacy and security guarantees of webxdc, 
 you may read [Bringing E2E privacy to the web](https://delta.chat/en/2023-05-22-webxdc-security) 
-which describes security-audited privacy guarantees not found with any other web container technology. 
+which describes security-audited privacy guarantees of webxdc not found with any other web container technology. 
 
 Removing central registries and app stores means that 
 anyone can [get started building a HTML5 app](/get_started.html), 

--- a/src/intro.md
+++ b/src/intro.md
@@ -1,14 +1,46 @@
-# Intro 
+# From HTTP to P2P web apps
 
-Webxdc is a new way to create and share web apps in messenger chat groups. Anyone can build HTML5 apps, package it as a [`.xdc` file](./spec/index.html#webxdc-file-format), and drop it in a chat to share with friends. Once shared, chat participants can simply click "Start" to run the app and interact with each other through the app.
+Webxdc is a container format for sharing and hosting HTML5 web apps in messenger chats. 
+Instead of being hosted on a central always-online HTTP server, 
+webxdc apps are stored in a messenger app by attaching a container file to a chat message,
+and can be used while a device is offline even for extended periods. 
+Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
+webxdc apps send and receive messages via the messenger's [JavaScript API]
+which routes all "application updates" between users of an app.
+Webxdc app developers do not need to implement user accounts or discovery mechanisms,
+and they do not need to implement end-to-end encryption, 
+all of which are already provided by the messenger hosting the webxdc app. 
+
+While webxdc app development is vastly easier than developing for the HTTP Cloud
+there also are complications in arranging consistent web app state across user's devices. 
+The [Shared web application state] section 
+provides neccessary theoretical and practical background for writing robust offline-first web apps
+without requiring a central online authority acting as the "source of truth". 
+
+If you are interested in the privacy and security guarantees of webxdc, 
+you may read [Bringing E2E privacy to the web](https://delta.chat/en/2023-05-22-webxdc-security) 
+which describes security-audited privacy guarantees not found with any other web container technology. 
+
+Removing central registries and app stores means that 
+anyone can [get started building a HTML5 app](/get_started.html), 
+package it as a [`.xdc` container file](./spec/index.html#webxdc-file-format), 
+and drop it in a chat to share with friends. 
+Once shared, chat participants can simply click "Start" 
+to run the app and interact with each other through the app.
 
 <video controls style="width:560px; max-width: 100%;"><source src="https://webxdc.org/assets/just-web-apps.mp4" type="video/mp4"><a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch "just web apps" on youtube</a></video>
 
-Webxdc apps can only send and receive messages in the chat via the messenger's [JavaScript API]. Thus they automatically get end-to-end encryption and peer discovery for free.
+The [webxdc-dev simulation tool](https://github.com/webxdc/webxdc-dev) is the recommended 
+tool for developing webxdc apps as it allows simulation of multiple app users,
+supports different screen formats and allows observing network messages between app instances. 
+No messenger is required to develop a webxdc app with the `webxdc-dev` tool. 
 
-Webxdc is specified through its [file format](/spec/index.html#webxdc-file-format) for packaging as a `.xdc` file, [JavaScript API] for developing web apps, and [Messenger implementation] for running and sharing Webxdc apps in chats. Webxdc is supported by and evolving with the [Delta Chat](https://delta.chat) e-mail messenger, which serves as the default reference.
+[webxdc on Codeberg](https://codeberg.org/webxdc) and [webxdc on GitHub](https://github.com/webxdc) 
+contain some of the ongoing webxdc-related developments.  
 
-See the [webxdc GitHub organization](https://github.com/webxdc) for further developments and feel free to post questions or suggestions in the [Webxdc support forum](https://support.delta.chat/c/webxdc/20).
+Please feel free to post or follow questions and answers 
+in the [Webxdc support forum](https://support.delta.chat/c/webxdc/20). 
 
+[Shared web application state]: /shared-state/index.html 
 [JavaScript API]: /spec/index.html#webxdc-api
 [Messenger implementation]: /spec/index.html#messenger-implementation

--- a/src/intro.md
+++ b/src/intro.md
@@ -8,7 +8,7 @@ Instead of being hosted on a central always-online HTTP server,
 webxdc apps are stored with the host messenger by attaching a container file to a chat message. 
 Instead of using the HTTP protocol for querying a central server to obtain authoritative application state,
 webxdc apps send and receive messages via the messenger's [JavaScript API]
-which allows to send and receive "application updates" between devices particpating in a chat. 
+which allows to send and receive "application updates" between devices participating in a chat. 
 App developers do not need to implement message transport, user authentication, 
 discovery or bootstrapping mechanisms, and they do not need to implement end-to-end encryption either. 
 All Authentication, identity management, social discovery and message transport 
@@ -18,10 +18,10 @@ capabilities of the hosting messenger.
 
 Messengers run webxdc container files in network-isolated webviews that can not perform any DNS or HTTP queries.
 Webxdc apps can only cause network messages by calling the [`sendUpdate`](./spec/sendUpdate.html)
-and [`setUpdateListener`](./spec/setUpdateListener.html) Javasript APIs,
+and [`setUpdateListener`](./spec/setUpdateListener.html) JavaScript APIs,
 implemented by the hosting messenger. 
 In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security) 
-Delta Chat developers described the unqiue security-audited privacy guarantees of webxdc 
+Delta Chat developers described the unique security-audited privacy guarantees of webxdc 
 not found with any other web container technology or [specification](./spec/index.html). 
 
 Waving central registries and app store dependencies "good bye!", 
@@ -50,7 +50,7 @@ The [Shared web application state] chapter
 provides useful theoretical and practical background for writing robust offline-first web apps
 without requiring a central online authority acting as the "source of truth". 
 Even if you don't study the topic in depth, reading [Shared web application state] 
-introduces you to the terminology and neccessary considerations 
+introduces you to the terminology and necessary considerations 
 for any P2P system, with a particular eye on webxdc. 
 
 

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -15,7 +15,7 @@ Messenger implementations expose the API through a `webxdc.js` module. To activa
 `webxdc.js` must not be added to your `.xdc` file as they are provided by the messenger. To simulate webxdc in a browser, 
 you may use the `webxdc.js` file from [Hello](https://github.com/webxdc/hello),
 or use the [webxdc-dev tool](https://github.com/webxdc/webxdc-dev) which
-allows to simulate and debug running webxdc apps without any messenger.
+both allow to simulate and debug webxdc apps without any messenger.
 
 ## Webxdc File Format
 

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -1,7 +1,6 @@
 # Webxdc Specification
 
-Webxdc is a fresh and still evolving way of running web apps in chat messengers. 
-This document is for app developers and outlines the [webxdc API](#webxdc-api) and [`.xdc` file format](#webxdc-file-format). It also describes the constraints for a [messenger implementation](#messenger-implementation) when running webxdc apps. 
+This document is for app developers and outlines the [webxdc API](#webxdc-api) and [`.xdc` file format](#webxdc-file-format). It also describes the constraints for a [messenger implementation](#messenger-implementation) for hosting and running webxdc apps. 
 
 ## Webxdc API
 
@@ -13,7 +12,10 @@ Messenger implementations expose the API through a `webxdc.js` module. To activa
 <script src="webxdc.js"></script>
 ```
 
-`webxdc.js` must not be added to your `.xdc` file as they are provided by the messenger. To simulate webxdc in a browser, use the `webxdc.js` file from [Hello](https://github.com/webxdc/hello).
+`webxdc.js` must not be added to your `.xdc` file as they are provided by the messenger. To simulate webxdc in a browser, 
+you may use the `webxdc.js` file from [Hello](https://github.com/webxdc/hello),
+or use the [webxdc-dev tool](https://github.com/webxdc/webxdc-dev) which
+allows to simulate and debug running webxdc apps without any messenger.
 
 ## Webxdc File Format
 

--- a/src/spec/importFiles.md
+++ b/src/spec/importFiles.md
@@ -4,7 +4,7 @@
 let files = await window.webxdc.importFiles(filter);
 ```
 
-`importFiles()` (requires Delta Chat 1.38 or compatible) allows a webxdc app to import files.
+`importFiles()` allows a webxdc app to import files.
 Depending on platform support, this just opens the system file picker or a custom one.
 This custom file picker should show recent attachments that were received and sent,
 to make importing of a file that you just received from someone easier

--- a/src/spec/sendToChat.md
+++ b/src/spec/sendToChat.md
@@ -4,7 +4,7 @@
 let promise = window.webxdc.sendToChat(message);
 ```
 
-`sendToChat()` (requires Delta Chat 1.38 or compatible) allows a webxdc app to prepare a message
+`sendToChat()` allows a webxdc app to prepare a message
 that can then be sent to a chat by the user.
 Implementations may ask the user for a destination chat
 and then set up the message as a draft,


### PR DESCRIPTION
- talk about messengers and not Delta Chat (in particular not about the ancient 1.38) 
- Rewrite Intro to mention and reference more content, and describe the basic "HTTP -> P2P" move 
- more prominently link webxdc-dev tool for development 
 